### PR TITLE
fix(chrome): DevToolsActivePort file doesn't exist error on linux (#8)

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -37,7 +37,7 @@ const (
 	// See https://omahaproxy.appspot.com for a list of current releases.
 	//
 	// Update this periodically.
-	desiredChromeBuild = "664981" // This corresponds to version 76.0.3809.0
+	desiredChromeBuild = "885287"
 
 	// desiredFirefoxVersion is the known version of Firefox to download.
 	//

--- a/engine.go
+++ b/engine.go
@@ -110,6 +110,7 @@ func (s *Selenium) InitChromeWebDriver() {
 		Args: []string{
 			"--disable-extensions",
 			"--disable-infobars",
+			"--disable-dev-shm-usage",
 			"--no-sandbox",
 			"--window-size=360,640",
 		},


### PR DESCRIPTION
+ chore: bump chrome/chromedriver to build 885287